### PR TITLE
Patch/ship babel runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,23 +5,40 @@
 npm install react-docgen-imported-proptype-handler --save-dev
 ```
 
-### Usage
+### Usage example
 ```js
+const { readFileSync, writeFileSync } = require('fs');
+const { resolve, basename } = require('path');
 const docgen = require('react-docgen');
-const importedProptypesHandler = require('react-docgen-imported-proptype-handler');
+const glob = require('glob');
+const importedProptypesHandler = require('react-docgen-imported-proptype-handler').default;
 
-let metadata = files.map(filepath => {
+const FILES = glob.sync('src/components/**/*.{js,jsx}');
+
+const metadata = FILES.reduce((memo, filepath) => {
   /* append display name handler to handlers list */
-  const handlers = docgen.defaultHandlers.concat(importedProptypesHandler(filepath));
+  const handlers = docgen.defaultHandlers.concat([
+    importedProptypesHandler(filepath)
+  ]);
 
   /* read file to get source code */
-  const code = fs.readFileSync(path, 'utf8');
+  const code = readFileSync(filepath, 'utf8');
 
   /* parse the component code to get metadata */
-  const data = docgen.parse(code, null, handlers);
+  try {
+    const data = docgen.parse(code, null, handlers);
+    memo[basename(filepath)] = data;
+  } catch (err) {
+    if (err.message !== 'No suitable component definition found.') {
+      console.log('ERROR:', filepath, err);
+    }
+  }
 
-  return data;
-});
+  return memo;
+}, {});
+
+
+writeFileSync(resolve(process.cwd(), 'DOCGEN_OUTPUT.json'), JSON.stringify(metadata, null, 2));
 ```
 
 #### Credit

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-docgen-external-proptypes-handler",
+  "name": "react-docgen-imported-proptype-handler",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -792,7 +792,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
       "integrity": "sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==",
-      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.12.0"
       },
@@ -800,8 +799,7 @@
         "regenerator-runtime": {
           "version": "0.12.1",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
-          "dev": true
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-docgen-imported-proptype-handler",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "evaluate imported variables for react-docgen",
   "scripts": {
     "build": "rimraf dist/ && babel src/ --out-dir dist/ --ignore **/__tests__,**/__mocks__,**/src/types.js",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@babel/core": "^7.2.0",
     "@babel/plugin-transform-runtime": "^7.2.0",
     "@babel/preset-env": "^7.2.0",
-    "@babel/runtime": "^7.2.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",
     "babel-jest": "^23.6.0",
@@ -47,6 +46,7 @@
     "testRegex": "/__tests__/.*-test\\.js$"
   },
   "dependencies": {
+    "@babel/runtime": "^7.2.0",
     "react-docgen": "2.21.0",
     "recast": "^0.12.9"
   }


### PR DESCRIPTION
forgot to ship `@babel/runtime`

also, updates readme with real example usage